### PR TITLE
Fixes and improvements in installation guide and in migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Contributing
 ------------
 
 PyCon CZ website is using Python 3.5/Django for the backend, NodeJS/webpack for
-bundling frontend assets and Postgresql as a database (SQLite in dev).
+bundling frontend assets and Postgresql as a database.
 
 ### Setup dev environment
 
@@ -16,19 +16,27 @@ bundling frontend assets and Postgresql as a database (SQLite in dev).
 Inside `pyconcz_2016` directory,
 run following commands to setup project for local development:
 
-1. Prepare postgresql database: user `pyconcz`, database `pyconcz`
-1. `mkvirtualenv -p python3.5 pyconcz`
-2. `pip install -r dev-requirements.txt`
-3. `./manage.py migrate`
-4. `./manage.py runserver`
-5. Open [http://localhost:8000]()
+1.  Prepare postgresql database: user `pyconcz`, password empty, database `pyconcz`
+
+    E.g. on Mac:
+
+    ```
+    $ createuser --pwprompt pyconcz
+    $ createdb -Opyconcz -Eutf8 pyconcz
+    ```
+
+2.  `python3 -m venv env`
+3.  `pip install -r requirements-dev.txt`
+4.  `./manage.py migrate`
+5.  `./manage.py runserver`
+6.  Open [http://localhost:8000]()
 
 If and **only if** you also want to work with styles and javascript, you need to have `node.js`.
 Inside root directory (the same directory where `manage.py` is) run following commands:
 
-1. Add following line to your `/etc/hosts` file: `127.0.0.1 lan.pycon.cz`.
-2. `npm install`
-3. `npm start`
+1.  Add following line to your `/etc/hosts` file: `127.0.0.1 lan.pycon.cz`.
+2.  `npm install`
+3.  `npm start`
 
 Now open [http://lan.pycon.cz:8000]() and you should have development version of
 website with webpack hot reloading enabled.

--- a/pyconcz_2016/speakers/migrations/0012_auto_20161011_1110.py
+++ b/pyconcz_2016/speakers/migrations/0012_auto_20161011_1110.py
@@ -10,7 +10,8 @@ def migrate_talks(apps, schema_editor):
     ContentType = apps.get_model("contenttypes", "ContentType")
     Slot = apps.get_model("speakers", "Slot")
 
-    TalkType = ContentType.objects.get(app_label="speakers", model="talk")
+    # `get_or_create` because of http://stackoverflow.com/q/31539690/325365
+    TalkType, created = ContentType.objects.get_or_create(app_label="speakers", model="talk")
 
     Slot.objects.exclude(talk=None).update(
         object_id=F('talk_id'),


### PR DESCRIPTION
My changes:
- Mentioning SQLite gave me a wrong hope I won't need PostgreSQL for development.
- Migrations didn't work out of the box with a brand new installation.
- Not everyone uses `mkvirtualenv` and whoever uses it, is able to translate `python -m venv env` to his way.
- Not clear way how to setup PostgreSQL for a person who doesn't work with it daily.
